### PR TITLE
Fix typo in info.json homepage url

### DIFF
--- a/src/info.json
+++ b/src/info.json
@@ -4,7 +4,7 @@
   "title": "Cybersyn Combinator",
   "author": "Sharparam",
   "contact": "sharparam@sharparam.com",
-  "homepage": "https://github.com/Sharparm/cybersyn-combinator",
+  "homepage": "https://github.com/Sharparam/cybersyn-combinator",
   "description": "A specialized combinator for the Project Cybersyn mod",
   "factorio_version": "1.1",
   "dependencies": [


### PR DESCRIPTION
## Description
There's a missing "a" in the homepage url.

## Motivation and context
The current link leads to a 404 page.

## How has this been tested?
Clicked the link.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Go over all the following points, and put an `X` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [X] My code follows the code style of this project.
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
 - [X] I have read the **CONTRIBUTING** document.
 - [ ] I have added tests to cover my changes where applicable.
 - [ ] All new and existing tests passed.

<!-- You can find a link to the CONTRIBUTING document -->
<!-- near the top of this page. -->
